### PR TITLE
Avoid unnecessary code and change the type of accelerator_enabled

### DIFF
--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -470,7 +470,7 @@ static ZEND_FUNCTION(accelerator_get_status)
 	array_init(return_value);
 
 	/* Trivia */
-	add_assoc_long(return_value, "accelerator_enabled", ZCG(startup_ok) && ZCSG(accelerator_enabled));
+	add_assoc_bool(return_value, "accelerator_enabled", 1);
 	add_assoc_bool(return_value, "cache_full", ZSMMG(memory_exhausted));
 
 	/* Memory usage statistics */


### PR DESCRIPTION
accelerator_enabled will always be true when accelerator_get_status
returns an array. Also the accelerator_enabled should be a boolean
and not a long
