### PR TITLE
Add optional flag to opcache_get_status()

### DIFF
--- a/ZendAccelerator.h
+++ b/ZendAccelerator.h
@@ -259,6 +259,9 @@ typedef struct _zend_accel_shared_globals {
 	unsigned long   hits;
 	unsigned long   misses;
 	unsigned long   blacklist_misses;
+	unsigned long   oom_restarts;
+	unsigned long   hash_restarts;
+	unsigned long   manual_restarts;
 	zend_accel_hash hash;             /* hash table for cached scripts */
 	zend_accel_hash include_paths;    /* used "include_path" values    */
 

--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -472,6 +472,9 @@ static ZEND_FUNCTION(opcache_get_status)
 	add_assoc_long(statistics, "max_cached_keys",    ZCSG(hash).max_num_entries);
 	add_assoc_long(statistics, "hits", ZCSG(hits));
 	add_assoc_long(statistics, "last_restart_time", ZCSG(last_restart_time));
+	add_assoc_long(statistics, "oom_restarts", ZCSG(oom_restarts));
+	add_assoc_long(statistics, "hash_restarts", ZCSG(hash_restarts));
+	add_assoc_long(statistics, "manual_restarts", ZCSG(manual_restarts));
 	add_assoc_long(statistics, "misses", ZSMMG(memory_exhausted)?ZCSG(misses):ZCSG(misses)-ZCSG(blacklist_misses));
 	add_assoc_long(statistics, "blacklist_misses", ZCSG(blacklist_misses));
 	reqs = ZCSG(hits)+ZCSG(misses);
@@ -577,6 +580,7 @@ static ZEND_FUNCTION(opcache_reset)
 		RETURN_FALSE;
 	}
 
+	ZCSG(manual_restarts)++;
 	zend_accel_schedule_restart(TSRMLS_C);
 	RETURN_TRUE;
 }

--- a/zend_shared_alloc.c
+++ b/zend_shared_alloc.c
@@ -277,6 +277,7 @@ static size_t zend_shared_alloc_get_largest_free_block(void)
 		zend_accel_error(ACCEL_LOG_WARNING, "Not enough free shared space to allocate %ld bytes (%ld bytes free)", (long)size, (long)ZSMMG(shared_free)); \
 		if (zend_shared_alloc_get_largest_free_block() < MIN_FREE_MEMORY) { \
 			ZSMMG(memory_exhausted) = 1;			\
+			ZCSG(oom_restarts)++; \
 			zend_accel_schedule_restart(TSRMLS_C);	\
 		} \
 	} while (0)


### PR DESCRIPTION
If we are just pulling out memory numbers or one of the other simple numbers in a Nagios job there is no point returning the thousands of cached scripts as well. This flag lets you turn off returning the scripts.
