### PR TITLE
add sample .ini file

### DIFF
--- a/opcache.ini
+++ b/opcache.ini
@@ -1,0 +1,162 @@
+; Enable Zend OPcache extension
+zend_extension=opcache.so
+
+; OPcache On/Off switch. When set to Off, code is not optimized.
+; (default "1")
+opcache.enable = 1
+
+; Enables the OPcache for the CLI version of PHP.
+; It's mostly for testing and debugging.
+; (default "0")
+opcache.enable_cli = 0
+
+; The OPcache shared memory storage size.
+; The amount of memory for storing precompiled PHP code in Mbytes.
+; (default "64")
+opcache.memory_consumption = 64
+
+; The amount of memory for interned strings in Mbytes.
+; (default "4")
+opcache.interned_strings_buffer = 4
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; The number is actually the first one in the following set of prime numbers
+; that is bigger than the one supplied: { 223, 463, 983, 1979, 3907, 7963,
+; 16229, 32531, 65407, 130987 }. Only numbers between 200 and 100000 are
+; allowed.
+; (default "2000")
+opcache.max_accelerated_files = 2000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+; (default "5")
+opcache.max_wasted_percentage = 5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+; (default "1")
+opcache.use_cwd = 1
+
+; When disabled, you must reset the OPcache manually or restart the webserver
+; for changes to the filesystem to take effect. The frequency of the check is
+; controlled by the directive "opcache.revalidate_freq".
+; (default "1")
+opcache.validate_timestamps = 1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only once
+; per request. "0" means always validate)
+; (default "2")
+opcache.revalidate_freq = 2
+
+; Enables or disables file search in include_path optimization.
+; If the file search is disabled and a cached file is found that uses the same
+; include_path, the file is not searched again. Thus, if a file with the same
+; name appears somewhere else in include_path, it won't be found. Enable this
+; directive if this optimization has an effect on your applications. The
+; default for this directive is disabled, which means that optimization is
+; active.
+; (default "0")
+opcache.revalidate_path = 0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the size
+; of the optimized code. Disabling "Doc Comments" may break some existing
+; applications and frameworks (e.g. Doctrine, ZF2, PHPUnit)
+; (default "1")
+opcache.save_comments = 1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments" may
+; be always stored (save_comments=1), but not loaded by applications that don't
+; need them anyway.
+; (default "1")
+opcache.load_comments = 1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code. The
+; fast shutdown sequence doesn't free each allocated block, but lets the Zend
+; Engine Memory Manager do the work.
+; (default "0")
+opcache.fast_shutdown = 0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+; (default "0")
+opcache.enable_file_override = 0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache passes
+; (default "0xffffffff")
+opcache.optimization_level = 0xffffffff
+
+; Enable this hack as a workaround for "can't redeclare class" errors.
+; The OPcache stores the places where DECLARE_CLASS opcodes use inheritance
+; (These are the only opcodes that can be executed by PHP, but which may not be
+; executed because the parent class is missing due to optimization). When the
+; file is loaded, OPcache tries to bind the inherited classes by using the
+; current environment. The problem with this scenario is that, while the
+; DECLARE_CLASS opcode may not be needed for the current script, if the script
+; requires that the opcode at least be defined, it may not run. The default for
+; this directive is disabled, which means that optimization is active. In
+; php-5.3 and above this hack is not needed anymore and this setting has no
+; effect.
+; (default "1")
+opcache.inherited_hack = 1
+
+; The location of the OPcache blacklist file.
+; The OPcache blacklist file is a text file that holds the names of files that
+; should not be accelerated. The file format is to add each filename to a new
+; line. The filename may be a full path or just a file prefix (i.e., /var/www/x
+; blacklists all the files and directories in /var/www that start with 'x').
+; Files are usually triggered by one of the following three reasons:
+; 1) Directories that contain auto generated code, like Smarty or ZFW cache.
+; 2) Code that does not work well when accelerated, due to some delayed compile
+; time evaluation.
+; 3) Code that triggers an OPcache bug.
+; (default "")
+opcache.blacklist_filename = ""
+
+; Allows exclusion of large files from being cached. By default all files are
+; cached.
+; (default "0")
+opcache.max_file_size = 0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled. Because
+; calculating the checksum impairs performance, this directive should be
+; enabled only as part of a debugging process.
+; (default "0")
+opcache.consistency_checks = 0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed. The OPcache uses this directive to identify a
+; situation where there may be a problem with a process. After this time period
+; has passed, the OPcache assumes that something has happened and starts
+; killing the processes that still hold the locks that are preventing a
+; restart. If the log level is 3 or above, a "killed locker" error is recorded
+; in the Apache logs when this happens.
+; (default "180")
+opcache.force_restart_timeout = 180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+; (default "" which means stderr)
+opcache.error_log = ""
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged. You
+; can also enable warnings (level 2), info messages (level 3) or debug messages
+; (level 4).
+; (default "1")
+opcache.log_verbosity_level = 1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+; (default "")
+opcache.preferred_memory_model = ""
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+; (default "0")
+opcache.protect_memory = 0
+
+; Mapping base of shared memory segments (for Windows only). All the PHP
+; processes have to map shared memory into the same address space. This
+; directive allows to manually fix the "Unable to reattach to base address"
+; errors.
+;opcache.mmap_base = ""


### PR DESCRIPTION
it's useful for distributors to include well formatted ini file to be installed to conf.d. here's he start!

configurable options and their defaults taken with description from README

ideally could rename it to opcache.ini.in and process it during ./configure to include actual values there, like extension dir and extension. if there's interest i will try to do so!
