### PR TITLE
allow comments in blacklist file

### DIFF
--- a/zend_accelerator_blacklist.c
+++ b/zend_accelerator_blacklist.c
@@ -212,6 +212,11 @@ void zend_accel_blacklist_load(zend_blacklist *blacklist, char *filename)
 			continue;
 		}
 
+		/* skip comments */
+		if (pbuf[0]=='#' || pbuf[0]==';') {
+			continue;
+		}
+
 		path_dup = zend_strndup(pbuf, path_length);
 		expand_filepath(path_dup, real_path TSRMLS_CC);
 		path_length = strlen(real_path);


### PR DESCRIPTION
I think this could be useful ;)

For packaging, this will allow to provide a default configuration with a default blacklist file with only some comments.

This patch use # and ; as comment start, perhaps you will prefer only ; to be consistent with php.ini
