### PR TITLE
higher limit for opcache.max_accelerated_files

### DIFF
--- a/README
+++ b/README
@@ -80,8 +80,8 @@ opcache.max_accelerated_files (default "2000")
 	The maximum number of keys (scripts) in the OPcache hash table.
 	The number is actually the first one in the following set of prime
 	numbers that is bigger than the one supplied: { 223, 463, 983, 1979, 3907,
-	7963, 16229, 32531, 65407, 130987 }. Only numbers between 200 and 100000
-	are allowed.
+	7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }. Only numbers
+	between 200 and 1000000 are allowed.
 
 opcache.max_wasted_percentage (default "5")
 	The maximum percentage of "wasted" memory until a restart is scheduled.

--- a/opcache.ini
+++ b/opcache.ini
@@ -22,8 +22,8 @@ opcache.interned_strings_buffer = 4
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; The number is actually the first one in the following set of prime numbers
 ; that is bigger than the one supplied: { 223, 463, 983, 1979, 3907, 7963,
-; 16229, 32531, 65407, 130987 }. Only numbers between 200 and 100000 are
-; allowed.
+; 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }. Only numbers between
+; 200 and 1000000 are allowed.
 ; (default "2000")
 opcache.max_accelerated_files = 2000
 

--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -34,7 +34,7 @@
 
 #define STRING_NOT_NULL(s) (NULL == (s)?"":s)
 #define MIN_ACCEL_FILES 200
-#define MAX_ACCEL_FILES 100000
+#define MAX_ACCEL_FILES 1000000
 #define TOKENTOSTR(X) #X
 
 static void (*orig_file_exists)(INTERNAL_FUNCTION_PARAMETERS) = NULL;


### PR DESCRIPTION
increased MAX_ACCEL_FILES, see prime_numbers in zend_accelerator_hash.c,
line 29
