### PR TITLE
Consistency for opcache.max_accelerated_files

### DIFF
--- a/README
+++ b/README
@@ -44,7 +44,7 @@ We recommend the following configuration options for best performance.
 
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=8
-opcache.max_accelerated_files=4000
+opcache.max_accelerated_files=3907
 opcache.revalidate_freq=60
 opcache.fast_shutdown=1
 opcache.enable_cli=1
@@ -76,7 +76,7 @@ opcache.memory_consumption (default "64")
 opcache.interned_strings_buffer (default "4")
 	The amount of memory for interned strings in Mbytes.
 
-opcache.max_accelerated_files (default "2000")
+opcache.max_accelerated_files (default "3907")
 	The maximum number of keys (scripts) in the OPcache hash table.
 	The number is actually the first one in the following set of prime
 	numbers that is bigger than the one supplied: { 223, 463, 983, 1979, 3907,

--- a/ZendAccelerator.c
+++ b/ZendAccelerator.c
@@ -2461,8 +2461,8 @@ static int zend_accel_init_shm(TSRMLS_D)
 	}
 	ZSMMG(app_shared_globals) = accel_shared_globals;
 
-	zend_accel_hash_init(&ZCSG(hash), ZCG(accel_directives).max_accelerated_files);
-	zend_accel_hash_init(&ZCSG(include_paths), 32);
+	ZCG(accel_directives).max_accelerated_files = zend_accel_hash_init(&ZCSG(hash), ZCG(accel_directives).max_accelerated_files);
+	zend_accel_hash_init(&ZCSG(include_paths), 53);
 
 #if ZEND_EXTENSION_API_NO > PHP_5_3_X_API_NO
 

--- a/opcache.ini
+++ b/opcache.ini
@@ -25,7 +25,7 @@ opcache.interned_strings_buffer = 4
 ; 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }. Only numbers between
 ; 200 and 1000000 are allowed.
 ; (default "2000")
-opcache.max_accelerated_files = 2000
+opcache.max_accelerated_files = 3907
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ; (default "5")

--- a/zend_accelerator_hash.c
+++ b/zend_accelerator_hash.c
@@ -36,7 +36,7 @@ void zend_accel_hash_clean(zend_accel_hash *accel_hash)
 	memset(accel_hash->hash_table, 0, sizeof(zend_accel_hash_entry *)*accel_hash->max_num_entries);
 }
 
-void zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size)
+zend_uint zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size)
 {
 	uint i;
 
@@ -46,7 +46,6 @@ void zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size)
 			break;
 		}
 	}
-
 	accel_hash->num_entries = 0;
 	accel_hash->num_direct_entries = 0;
 	accel_hash->max_num_entries = hash_size;
@@ -55,16 +54,18 @@ void zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size)
 	accel_hash->hash_table = zend_shared_alloc(sizeof(zend_accel_hash_entry *)*accel_hash->max_num_entries);
 	if (!accel_hash->hash_table) {
 		zend_accel_error(ACCEL_LOG_FATAL, "Insufficient shared memory!");
-		return;
+		return 0;
 	}
 
 	/* set up hash values table */
 	accel_hash->hash_entries = zend_shared_alloc(sizeof(zend_accel_hash_entry)*accel_hash->max_num_entries);
 	if (!accel_hash->hash_entries) {
 		zend_accel_error(ACCEL_LOG_FATAL, "Insufficient shared memory!");
-		return;
+		return 0;
 	}
 	memset(accel_hash->hash_table, 0, sizeof(zend_accel_hash_entry *)*accel_hash->max_num_entries);
+
+	return hash_size;
 }
 
 /* Returns NULL if hash is full

--- a/zend_accelerator_hash.h
+++ b/zend_accelerator_hash.h
@@ -61,7 +61,7 @@ typedef struct _zend_accel_hash {
 	zend_uint               num_direct_entries;
 } zend_accel_hash;
 
-void zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size);
+zend_uint zend_accel_hash_init(zend_accel_hash *accel_hash, zend_uint hash_size);
 void zend_accel_hash_clean(zend_accel_hash *accel_hash);
 
 zend_accel_hash_entry* zend_accel_hash_update(

--- a/zend_accelerator_module.c
+++ b/zend_accelerator_module.c
@@ -254,7 +254,7 @@ ZEND_INI_BEGIN()
 #if ZEND_EXTENSION_API_NO > PHP_5_3_X_API_NO
 	STD_PHP_INI_ENTRY("opcache.interned_strings_buffer", "4"  , PHP_INI_SYSTEM, OnUpdateLong,                 accel_directives.interned_strings_buffer,   zend_accel_globals, accel_globals)
 #endif
-	STD_PHP_INI_ENTRY("opcache.max_accelerated_files" , "2000", PHP_INI_SYSTEM, OnUpdateMaxAcceleratedFiles,	 accel_directives.max_accelerated_files,     zend_accel_globals, accel_globals)
+	STD_PHP_INI_ENTRY("opcache.max_accelerated_files" , "3907", PHP_INI_SYSTEM, OnUpdateMaxAcceleratedFiles,	 accel_directives.max_accelerated_files,     zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.max_wasted_percentage" , "5"   , PHP_INI_SYSTEM, OnUpdateMaxWastedPercentage,	 accel_directives.max_wasted_percentage,     zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.consistency_checks"    , "0"   , PHP_INI_ALL   , OnUpdateLong,	             accel_directives.consistency_checks,        zend_accel_globals, accel_globals)
 	STD_PHP_INI_ENTRY("opcache.force_restart_timeout" , "180" , PHP_INI_SYSTEM, OnUpdateLong,	             accel_directives.force_restart_timeout,     zend_accel_globals, accel_globals)


### PR DESCRIPTION
From README

```
The number is actually the first one in the following set of prime
numbers that is bigger than the one supplied: { 223, 463, 983, 1979, 3907,
7963, 16229, 32531, 65407, 130987, 262237, 524521, 1048793 }. Only numbers
```

Make default value + opcache.ini consistent with this
(so 3907 instead of 2000, as this is the real value used)

Also report the real value in opcache_get_configuration.
