### PR TITLE
useless 'instanceof' removal pass

### DIFF
--- a/Optimizer/pass1_5.c
+++ b/Optimizer/pass1_5.c
@@ -13,6 +13,20 @@ if (ZEND_OPTIMIZER_PASS_1 & OPTIMIZATION_LEVEL) {
 
 	while (opline < end) {
 		switch (opline->opcode) {
+		case ZEND_INSTANCEOF:
+			if ((opline + 1)->opcode == ZEND_FREE) { /* useless instanceof */
+				MAKE_NOP(opline);
+				MAKE_NOP((opline + 1));
+
+				/* It is safe to remove FETCH_CLASS, it was ZEND_FETCH_CLASS_NO_AUTOLOAD anyway */
+				if ((opline - 1)->opcode == ZEND_FETCH_CLASS) {
+					if (ZEND_OP2_TYPE(opline - 1) == IS_CONST) {
+						literal_dtor(&ZEND_OP2_LITERAL(opline - 1));
+					}
+					MAKE_NOP((opline -1));
+				}
+			}
+		break;
 		case ZEND_ADD:
 		case ZEND_SUB:
 		case ZEND_MUL:


### PR DESCRIPTION
I met some users that used such statements just to hint their IDE about auto-completion.

$a instanceof Foo;

This is a useless statement that gets compiled and run every time for nothing (usually 3 OPCodes involved)

This PR adds a pass to optimize such statement
