### PR TITLE
Make killing a locker an ERROR event.

### DIFF
--- a/ZendAccelerator.c
+++ b/ZendAccelerator.c
@@ -573,7 +573,7 @@ static inline void kill_all_lockers(struct flock *mem_usage_check)
 	ZCSG(force_restart_time) = 0;
 	while (mem_usage_check->l_pid > 0) {
 		while (tries--) {
-			zend_accel_error(ACCEL_LOG_INFO, "Killed locker %d", mem_usage_check->l_pid);
+			zend_accel_error(ACCEL_LOG_ERROR, "Killed locker %d", mem_usage_check->l_pid);
 			if (kill(mem_usage_check->l_pid, SIGKILL)) {
 				break;
 			}
@@ -586,7 +586,7 @@ static inline void kill_all_lockers(struct flock *mem_usage_check)
 			usleep(10000);
 		}
 		if (!tries) {
-			zend_accel_error(ACCEL_LOG_INFO, "Can't kill %d after 20 tries!", mem_usage_check->l_pid);
+			zend_accel_error(ACCEL_LOG_ERROR, "Can't kill %d after 20 tries!", mem_usage_check->l_pid);
 			ZCSG(force_restart_time) = time(NULL); /* restore forced restart request */
 		}
 


### PR DESCRIPTION
At least in apache, killing a locker with SIGKILL from inside opcache prevents
the child process from emitting a corresponding log event to the access or
error logs, therefore requests are termed with no record.  This makes is
incredibly difficult to debug problems espically on systems with high counts
of cache restarts.  Since INFO level is far too noisy for production use,
switch the killing to a higher level so we can see it easier.